### PR TITLE
Patch 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function ParadoxSecuritySystemAccessory(log, config) {
     this.statetopic = config["statetopic"];
     this.armevent = config["armevent"];
     this.stayevent = config["stayevent"];
+    this.nightevent = config["nightevent"]  || "Event:Non-reportable event;SubEvent:Arm in sleep mode";
     this.disarmevent = config["disarmevent"];
     this.triggeredevent = config["triggeredevent"];
 
@@ -61,6 +62,9 @@ function ParadoxSecuritySystemAccessory(log, config) {
                 break;
             case self.stayevent:
                 status = Characteristic.SecuritySystemCurrentState.STAY_ARM;
+                break;
+            case self.nightevent:
+                status = Characteristic.SecuritySystemCurrentState.NIGHT_ARM;
                 break;
             case self.disarmevent:
                 status = Characteristic.SecuritySystemCurrentState.DISARMED;

--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ function ParadoxSecuritySystemAccessory(log, config) {
     this.armevent = config["armevent"];
     this.stayevent = config["stayevent"];
     this.nightevent = config["nightevent"]  || "Event:Non-reportable event;SubEvent:Arm in sleep mode";
-    this.disarmevent = config["disarmevent"];
-    this.triggeredevent = config["triggeredevent"];
+    this.disarmevent = config["disarmevent"] || "Event:Partition status;SubEvent:Disarm partition";
+    this.triggeredevent = config["triggeredevent"] || "Event:Zone in alarm";
 
 	// connect to MQTT broker connection settings
 	this.client_Id = 'mqttjs_' + Math.random().toString(16).substr(2, 8);

--- a/sample-config.json
+++ b/sample-config.json
@@ -5,20 +5,20 @@
         "port": 51826,
         "pin": "031-45-154"
     },
-
-    "accessories": [
+   "accessories": [
         {
-            "accessory": "Homebridge-Paradox",
-            "name": "Alarm System",
-            "mqttusername": "",
-            "mqttpassword": "",
-            "mqttserver": "mqtt://localhost",
-            "controltopic": "Paradox/C/P1",
-	        "statetopic": "Paradox/Events",
-	        "stayevent": "Event:Non-reportable event;SubEvent:Arm in stay mode",
-	        "armevent": "Event:Partition status;SubEvent:Arm partition",
-	        "disarmevent": "Event:Partition status;SubEvent:Disarm partition",
-	        "triggeredevent": ""
+        "accessory": "Homebridge-Paradox",
+        "name": "Alarm System",
+        "mqttusername": "",
+        "mqttpassword": "",
+        "mqttserver": "mqtt://localhost",
+        "controltopic": "Paradox/C/P1",
+        "statetopic": "Paradox/Events",
+        "nightevent": "Event:Non-reportable event;SubEvent:Arm in sleep mode",
+        "stayevent": "Event:Non-reportable event;SubEvent:Arm in stay mode",
+        "armevent": "Event:Partition status;SubEvent:Arm partition",
+        "disarmevent": "Event:Partition status;SubEvent:Disarm partition",
+        "triggeredevent": "Event:Zone in alarm"
         }
-    ]
+    ],
 }

--- a/sample-config.json
+++ b/sample-config.json
@@ -5,6 +5,7 @@
         "port": 51826,
         "pin": "031-45-154"
     },
+    
    "accessories": [
         {
         "accessory": "Homebridge-Paradox",


### PR DESCRIPTION
No Need to change Config File
Tested - No conflict at time of test

Bug - State update for Alarm causes Home.IOS to report unreachable (while system in alarm)
Bug - Reboot causes State Loss - No way to resolve without update from Mqqt side to pull current state on Load or Mqqt side to use persistent Topics split over Update Types :zone // :Status //: 
Other solution is to use storage file for last state, but that is not reliable to current state of alarm.

Proposal would be 
/Paradox/Zone01/Name/Frontdoor
/Paradox/Zone01/Status/0 [Persistent]
/Paradox/Partition1/Status/Arm [Armed/Sleep/Stay/Disarmed]